### PR TITLE
```

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,8 @@
 ## PR检查表
 
 - 该项目主要的工作分支有`main`和`dev`
-  - 请尽量从`main`分支拉取代码，该分支为稳定代码
+  - `main`分支包含的是已经发布的功能，请勿提交PR到`main`分支。
+  - 如要贡献代码，请从`dev`分支拉取代码，该分支一般包含最新待上线的功能。
   - 你的代码提交（添加新功能、修复bug、优化性能等）需要发起PR到`dev`分支
   - 请尽可能地在您的PR请求中描述清楚添加的功能或者修复的问题
   - 在一个PR中有多个小提交是没问题的，但请确保每个提交都包含一个清晰的提交信息。
@@ -24,25 +25,33 @@ pnpm install  # 安装依赖
 ## 运行脚本
 
 ### `pnpm dev`
+
 启动开发服务器
+
 ```bash
 pnpm dev
 ```
 
 ### `pnpm build`
+
 构建项目
+
 ```bash
 pnpm build
 ```
 
 ### `pnpm build:file`
+
 打包后的项目可以直接通过html文件的形式直接在浏览器打开
+
 ```bash
 pnpm build:file
 ```
 
 ### `pnpm lint:fix`
+
 修复eslint格式错误
+
 ```bash
 pnpm lint:fix
 ```
@@ -50,6 +59,7 @@ pnpm lint:fix
 ## 项目结构
 
 src目录下基本放置了所有的代码文件，其中最主要的是
+
 - `views`：存放页面代码
 - `components`：存放组件代码
 - `utils`：存放工具函数


### PR DESCRIPTION
docs(CONTRIBUTING.md): 更新贡献指南中的分支说明和运行脚本描述

更新了 PR 检查表中关于 main 和 dev 分支的使用说明，明确禁止向 main 分支提交 PR。 同时补充了各个 pnpm 脚本的详细说明和执行方式，并完善了项目结构部分的描述。
```