### PR TITLE
fix: 修复删除奖项后数据未同步更新的问题

### DIFF
--- a/src/views/Config/Prize/usePrizeConfig.ts
+++ b/src/views/Config/Prize/usePrizeConfig.ts
@@ -80,6 +80,7 @@ export function usePrizeConfig() {
 
     function delItem(item: IPrizeConfig) {
         prizeConfig.deletePrizeConfig(item.id)
+        prizeList.value = prizeList.value.filter(i => i.id !== item.id)
         toast.success(i18n.global.t('error.deleteSuccess'))
     }
     function addPrize() {


### PR DESCRIPTION
## 问题描述
删除奖项提示成功，但实际数据未删除。

## 原因分析
 `delItem` 函数只删除了 Pinia Store 中的数据，但页面绑定的是通过 `cloneDeep` 创建的本地副本 `prizeList`，该副本没有同步更新。

## 修复方案
在删除 store 数据的同时，过滤掉本地副本中对应的项。

Closes #224 