### PR TITLE
feat(prize): 添加奖项配置 Excel 导入导出功能

### DIFF
--- a/src/locales/modules/button.ts
+++ b/src/locales/modules/button.ts
@@ -25,6 +25,11 @@ export const buttonEn = {
     noInfoAndImport: 'No Info and import it',
     useDefault: 'Use Default Data',
     loading: 'Loading...',
+    import: 'Import',
+    export: 'Export',
+    prizeTemplateFileName: 'Prize Template.xlsx',
+    prizeTemplateExample: 'First Prize',
+    prizeExportFileName: 'Prize Config',
 }
 
 export const buttonZhCn = {
@@ -54,6 +59,11 @@ export const buttonZhCn = {
     noInfoAndImport: '暂无人员信息，前往导入',
     useDefault: '使用默认数据',
     loading: '加载中...',
+    import: '导入',
+    export: '导出',
+    prizeTemplateFileName: '奖项配置模板.xlsx',
+    prizeTemplateExample: '一等奖',
+    prizeExportFileName: '奖项配置',
 }
 
 // 导出一个值

--- a/src/locales/modules/table.ts
+++ b/src/locales/modules/table.ts
@@ -9,7 +9,7 @@ export const tableEn = {
     // person configuration
     number: 'Number',
     name: 'Name',
-    prizeName: 'Name',
+    prizeName: 'Prize Name',
     department: 'Department',
     avatar: 'Avatar',
     identity: 'Identity',
@@ -61,7 +61,7 @@ export const tableZhCn = {
     // person configuration
     number: '编号',
     name: '姓名',
-    prizeName: '名称',
+    prizeName: '奖项名称',
     department: '部门',
     avatar: '头像',
     identity: '身份',

--- a/src/views/Config/Prize/PrizeConfig.vue
+++ b/src/views/Config/Prize/PrizeConfig.vue
@@ -7,7 +7,7 @@ import EditSeparateDialog from '@/components/NumberSeparate/EditSeparateDialog.v
 import PageHeader from '@/components/PageHeader/index.vue'
 import { usePrizeConfig } from './usePrizeConfig'
 
-const { addPrize, resetDefault, delAll, delItem, prizeList, currentPrize, selectedPrize, submitData, changePrizePerson, changePrizeStatus, selectPrize, localImageList } = usePrizeConfig()
+const { addPrize, resetDefault, delAll, delItem, prizeList, currentPrize, selectedPrize, submitData, changePrizePerson, changePrizeStatus, selectPrize, localImageList, exportExcel, importExcel, downloadTemplate } = usePrizeConfig()
 const { t } = useI18n()
 </script>
 
@@ -18,6 +18,15 @@ const { t } = useI18n()
         <div class="flex w-full gap-3">
           <button class="btn btn-info btn-sm" @click="addPrize">
             {{ t('button.add') }}
+          </button>
+          <button class="btn btn-info btn-sm" @click="downloadTemplate">
+            {{ t('button.downloadTemplate') }}
+          </button>
+          <button class="btn btn-info btn-sm" @click="importExcel">
+            {{ t('button.import') }}
+          </button>
+          <button class="btn btn-info btn-sm" @click="exportExcel">
+            {{ t('button.export') }}
           </button>
           <button class="btn btn-info btn-sm" @click="resetDefault">
             {{ t('button.resetDefault') }}

--- a/src/views/Config/Prize/usePrizeConfig.ts
+++ b/src/views/Config/Prize/usePrizeConfig.ts
@@ -4,6 +4,7 @@ import { cloneDeep } from 'lodash-es'
 import { storeToRefs } from 'pinia'
 import { onMounted, ref, watch } from 'vue'
 import { useToast } from 'vue-toast-notification'
+import * as XLSX from 'xlsx'
 import i18n from '@/locales/i18n'
 import useStore from '@/store'
 
@@ -123,6 +124,72 @@ export function usePrizeConfig() {
         prizeConfig.setPrizeConfig(val)
     }, { deep: true })
 
+    function exportExcel() {
+        const data = prizeList.value.map(item => ({
+            [i18n.global.t('table.prizeName')]: item.name,
+            [i18n.global.t('table.numberParticipants')]: item.count,
+        }))
+        const ws = XLSX.utils.json_to_sheet(data)
+        const wb = XLSX.utils.book_new()
+        XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
+        const date = new Date().toISOString().split('T')[0]
+        XLSX.writeFile(wb, `${i18n.global.t('button.prizeExportFileName')}_${date}.xlsx`)
+        toast.success(i18n.global.t('error.success'))
+    }
+
+    function downloadTemplate() {
+        const data = [
+            {
+                [i18n.global.t('table.prizeName')]: i18n.global.t('button.prizeTemplateExample'),
+                [i18n.global.t('table.numberParticipants')]: 1,
+            },
+        ]
+        const ws = XLSX.utils.json_to_sheet(data)
+        const wb = XLSX.utils.book_new()
+        XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
+        XLSX.writeFile(wb, i18n.global.t('button.prizeTemplateFileName'))
+        toast.success(i18n.global.t('error.success'))
+    }
+
+    function importExcel() {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = '.xlsx,.xls'
+        input.onchange = (e: Event) => {
+            const file = (e.target as HTMLInputElement).files?.[0]
+            if (!file)
+                return
+            const reader = new FileReader()
+            reader.onload = (event) => {
+                const data = new Uint8Array(event.target?.result as ArrayBuffer)
+                const workbook = XLSX.read(data, { type: 'array' })
+                const sheetName = workbook.SheetNames[0]
+                const sheet = workbook.Sheets[sheetName]
+                const jsonData = XLSX.utils.sheet_to_json(sheet)
+
+                const newPrizes: IPrizeConfig[] = jsonData.map((row: any) => ({
+                    id: new Date().getTime().toString() + Math.random().toString(36).slice(2),
+                    name: row[i18n.global.t('table.prizeName')] || i18n.global.t('data.prizeName'),
+                    sort: 0,
+                    isAll: false,
+                    count: Number(row[i18n.global.t('table.numberParticipants')]) || 1,
+                    isUsedCount: 0,
+                    picture: { id: '', name: '', url: '' },
+                    separateCount: { enable: false, countList: [] },
+                    desc: '',
+                    isUsed: false,
+                    isShow: true,
+                    frequency: 1,
+                }))
+
+                prizeList.value = [...prizeList.value, ...newPrizes]
+                toast.success(i18n.global.t('error.success'))
+            }
+            reader.readAsArrayBuffer(file)
+        }
+        input.click()
+    }
+
     return {
         addPrize,
         resetDefault,
@@ -136,5 +203,8 @@ export function usePrizeConfig() {
         changePrizeStatus,
         selectPrize,
         localImageList,
+        exportExcel,
+        importExcel,
+        downloadTemplate,
     }
 }


### PR DESCRIPTION
## Summary
  - 新增下载模板功能，生成标准格式的 Excel 模板
  - 新增导入功能，支持从 Excel 批量导入奖项配置
  - 新增导出功能，将当前奖项配置导出为 Excel 文件
  - 添加相关国际化文案（中/英文）

  ## Test plan
  - [x] 点击下载模板，验证生成的 Excel 格式正确
  - [x] 导入模板数据，验证奖项正确添加
  - [x] 导出现有奖项，验证数据完整"